### PR TITLE
Fix ChromaDB cloud client configuration

### DIFF
--- a/core/services/chroma_task_sync_service.py
+++ b/core/services/chroma_task_sync_service.py
@@ -11,6 +11,7 @@ from typing import Optional, Dict, Any, List
 from datetime import datetime
 
 import chromadb
+from urllib.parse import urlparse, parse_qs
 
 
 logger = logging.getLogger('chroma_task_sync_service')
@@ -82,17 +83,8 @@ class ChromaTaskSyncService:
             if self.settings.chroma_api_key and self.settings.chroma_database and self.settings.chroma_tenant:
                 # Cloud configuration using HttpClient
                 logger.info("Initializing ChromaDB cloud client")
-                self._client = chromadb.HttpClient(
-                    host=self.settings.chroma_database,
-                    port=443,
-                    ssl=True,
-                    headers={
-                        "Authorization": f"Bearer {self.settings.chroma_api_key}",
-                        "X-Chroma-Token": self.settings.chroma_api_key
-                    },
-                    tenant=self.settings.chroma_tenant,
-                    database=self.settings.chroma_database
-                )
+                client_kwargs = self._build_cloud_client_kwargs()
+                self._client = chromadb.HttpClient(**client_kwargs)
             else:
                 # Local/persistent storage configuration
                 logger.info("Initializing ChromaDB local client")
@@ -112,6 +104,67 @@ class ChromaTaskSyncService:
                 "Failed to initialize ChromaDB client",
                 details=str(e)
             )
+
+    def _build_cloud_client_kwargs(self) -> Dict[str, Any]:
+        """Build keyword arguments for ChromaDB HttpClient configuration."""
+        raw_value = (self.settings.chroma_database or '').strip()
+
+        host = 'api.trychroma.com'
+        port = 443
+        use_ssl = True
+        database_name: Optional[str] = None
+
+        if raw_value:
+            is_plain_database = not any(ch in raw_value for ch in ('/', ':')) and 'http' not in raw_value.lower()
+
+            if is_plain_database:
+                database_name = raw_value
+            else:
+                value_to_parse = raw_value
+                if '://' not in value_to_parse:
+                    value_to_parse = f'https://{value_to_parse}'
+
+                parsed = urlparse(value_to_parse)
+                if parsed.hostname:
+                    host = parsed.hostname
+                if parsed.scheme == 'http':
+                    use_ssl = False
+                    port = parsed.port or 80
+                else:
+                    use_ssl = True
+                    port = parsed.port or 443
+
+                if parsed.path:
+                    path_parts = [segment for segment in parsed.path.split('/') if segment]
+                    if 'databases' in path_parts:
+                        idx = path_parts.index('databases')
+                        if idx + 1 < len(path_parts):
+                            database_name = path_parts[idx + 1]
+                    elif path_parts:
+                        database_name = path_parts[-1]
+
+                if not database_name:
+                    query_params = parse_qs(parsed.query)
+                    if 'database' in query_params and query_params['database']:
+                        database_name = query_params['database'][0]
+
+        headers = {
+            "Authorization": f"Bearer {self.settings.chroma_api_key}",
+            "X-Chroma-Token": self.settings.chroma_api_key
+        }
+
+        client_kwargs: Dict[str, Any] = {
+            'host': host,
+            'port': port,
+            'ssl': use_ssl,
+            'headers': headers,
+            'tenant': self.settings.chroma_tenant
+        }
+
+        if database_name:
+            client_kwargs['database'] = database_name
+
+        return client_kwargs
     
     def _generate_embedding(self, text: str) -> List[float]:
         """

--- a/main/test_chroma_task_sync_service.py
+++ b/main/test_chroma_task_sync_service.py
@@ -65,22 +65,35 @@ class ChromaTaskSyncServiceTest(TestCase):
         mock_client.assert_called_once_with(path="./chroma_db")
         mock_client.return_value.get_or_create_collection.assert_called_once()
     
-    @patch('core.services.chroma_task_sync_service.chromadb.Client')
+    @patch('core.services.chroma_task_sync_service.chromadb.HttpClient')
     def test_service_initialization_cloud(self, mock_client):
         """Test service initializes with cloud configuration"""
         # Update settings for cloud config
         self.settings.chroma_api_key = 'test-cloud-key'
-        self.settings.chroma_database = 'test-db'
+        self.settings.chroma_database = 'https://api.trychroma.com/api/v1/databases/test-db'
         self.settings.chroma_tenant = 'test-tenant'
         self.settings.save()
-        
+
         mock_collection = Mock()
         mock_client.return_value.get_or_create_collection.return_value = mock_collection
-        
+
         service = ChromaTaskSyncService(self.settings)
-        
+
         self.assertIsNotNone(service)
         mock_client.assert_called_once()
+        kwargs = mock_client.call_args.kwargs
+        self.assertEqual(kwargs['host'], 'api.trychroma.com')
+        self.assertTrue(kwargs['ssl'])
+        self.assertEqual(kwargs['port'], 443)
+        self.assertEqual(kwargs['tenant'], 'test-tenant')
+        self.assertEqual(kwargs['database'], 'test-db')
+        self.assertEqual(
+            kwargs['headers'],
+            {
+                'Authorization': 'Bearer test-cloud-key',
+                'X-Chroma-Token': 'test-cloud-key'
+            }
+        )
     
     def test_service_requires_settings(self):
         """Test service raises error without settings"""


### PR DESCRIPTION
## Summary
- normalize ChromaDB cloud configuration before instantiating the HttpClient for item and task sync
- ensure headers, host, and database name are derived correctly for cloud deployments
- update unit tests to validate the new HttpClient configuration logic

## Testing
- python manage.py test main.test_chroma_sync_service main.test_chroma_task_sync_service

------
https://chatgpt.com/codex/tasks/task_e_68f49e59400483278082d493bfdbb91b