### PR TITLE
Ensure local ChromaDB directory is writable

### DIFF
--- a/core/services/chroma_task_sync_service.py
+++ b/core/services/chroma_task_sync_service.py
@@ -6,11 +6,14 @@ Tasks are stored with their description as embeddings and metadata.
 """
 
 import logging
+import os
+from pathlib import Path
 import requests
 from typing import Optional, Dict, Any, List
 from datetime import datetime
 
 import chromadb
+from django.conf import settings as django_settings
 from urllib.parse import urlparse, parse_qs
 
 
@@ -88,7 +91,8 @@ class ChromaTaskSyncService:
             else:
                 # Local/persistent storage configuration
                 logger.info("Initializing ChromaDB local client")
-                self._client = chromadb.PersistentClient(path="./chroma_db")
+                local_path = self._prepare_local_client_path()
+                self._client = chromadb.PersistentClient(path=local_path)
             
             # Get or create collection
             self._collection = self._client.get_or_create_collection(
@@ -104,6 +108,35 @@ class ChromaTaskSyncService:
                 "Failed to initialize ChromaDB client",
                 details=str(e)
             )
+
+    def _prepare_local_client_path(self) -> str:
+        """Ensure a writable local directory exists for the ChromaDB client."""
+
+        configured_path = getattr(django_settings, 'CHROMADB_LOCAL_PATH', None)
+        if configured_path:
+            base_path = Path(configured_path)
+        else:
+            base_dir = getattr(django_settings, 'BASE_DIR', Path.cwd())
+            base_path = Path(base_dir) / 'chroma_db'
+
+        try:
+            base_path.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            logger.error(f"Failed to prepare local ChromaDB directory: {str(exc)}")
+            raise ChromaTaskSyncServiceError(
+                "Failed to prepare local ChromaDB directory",
+                details=str(exc)
+            )
+
+        if not os.access(base_path, os.W_OK):
+            error_message = f"Directory '{base_path}' is not writable"
+            logger.error(error_message)
+            raise ChromaTaskSyncServiceError(
+                "ChromaDB directory not writable",
+                details=error_message
+            )
+
+        return str(base_path)
 
     def _build_cloud_client_kwargs(self) -> Dict[str, Any]:
         """Build keyword arguments for ChromaDB HttpClient configuration."""

--- a/ideagraph/settings.py
+++ b/ideagraph/settings.py
@@ -128,6 +128,9 @@ USE_TZ = True
 STATIC_URL = 'static/'
 STATICFILES_DIRS = [BASE_DIR / 'static']
 
+# Local persistent storage for ChromaDB when cloud credentials are not provided
+CHROMADB_LOCAL_PATH = BASE_DIR / 'chroma_db'
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
 


### PR DESCRIPTION
## Summary
- ensure the ChromaDB item and task sync services prepare a writable local storage directory before using PersistentClient
- make the local path configurable via a Django setting and default it to BASE_DIR/chroma_db
- add explicit error reporting when the directory cannot be created or written to

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68f4a091f96483279f450d5f5a903604