### PR TITLE
Fix ForceAtlas2 UMD bundle loading

### DIFF
--- a/main/templates/main/items/detail.html
+++ b/main/templates/main/items/detail.html
@@ -834,7 +834,7 @@
 
 <!-- Sigma.js and dependencies for semantic network -->
 <script src="https://cdn.jsdelivr.net/npm/graphology@0.25.1/dist/graphology.umd.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/graphology-layout-forceatlas2@0.10.1/build/graphology-layout-forceatlas2.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/graphology-layout-forceatlas2@0.10.1/build/graphology-layout-forceatlas2.umd.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sigma@3.0.0-alpha3/build/sigma.min.js"></script>
 <script src="{% static 'main/js/semantic-network.js' %}"></script>
 

--- a/main/templates/main/milestones/detail.html
+++ b/main/templates/main/milestones/detail.html
@@ -852,7 +852,7 @@
 
 <!-- Sigma.js and dependencies for semantic network -->
 <script src="https://cdn.jsdelivr.net/npm/graphology@0.25.4/dist/graphology.umd.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/graphology-layout-forceatlas2@0.10.1/build/graphology-layout-forceatlas2.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/graphology-layout-forceatlas2@0.10.1/build/graphology-layout-forceatlas2.umd.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sigma@3.0.0-beta.20/build/sigma.min.js"></script>
 <script src="{% static 'main/js/semantic-network.js' %}"></script>
 <!-- Weaviate Indicator JavaScript -->

--- a/main/templates/main/tasks/detail.html
+++ b/main/templates/main/tasks/detail.html
@@ -525,7 +525,7 @@
 
 <!-- Sigma.js and dependencies for semantic network -->
 <script src="https://cdn.jsdelivr.net/npm/graphology@0.25.1/dist/graphology.umd.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/graphology-layout-forceatlas2@0.10.1/build/graphology-layout-forceatlas2.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/graphology-layout-forceatlas2@0.10.1/build/graphology-layout-forceatlas2.umd.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/sigma@3.0.0-alpha3/build/sigma.min.js"></script>
 <script src="{% static 'main/js/semantic-network.js' %}"></script>
 


### PR DESCRIPTION
## Summary
- load the ForceAtlas2 layout library from its UMD bundle so the global is exposed as expected
- update every semantic-network template to reference the corrected CDN asset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fcdadfb1c4832781803b4c8f4bf3c1