### PR TITLE
Fix milestone viewer init and sigma detection

### DIFF
--- a/main/static/main/js/semantic-network.js
+++ b/main/static/main/js/semantic-network.js
@@ -430,8 +430,10 @@ class SemanticNetworkViewer {
         
         // Create Sigma instance
         // Handle different possible Sigma namespaces
-        const SigmaConstructor = typeof Sigma !== 'undefined' ? Sigma : 
-                                 (typeof window.Sigma !== 'undefined' ? window.Sigma : null);
+        const SigmaConstructor = typeof Sigma !== 'undefined' ? Sigma :
+                                 (typeof window.Sigma !== 'undefined' ? window.Sigma :
+                                 (typeof sigma !== 'undefined' ? sigma :
+                                 (typeof window.sigma !== 'undefined' ? window.sigma : null)));
         
         if (!SigmaConstructor) {
             console.error('[SemanticNetwork] Sigma.js library not found. Cannot render graph.');

--- a/main/templates/main/milestones/detail.html
+++ b/main/templates/main/milestones/detail.html
@@ -1792,7 +1792,7 @@ document.getElementById('semantic-network-tab')?.addEventListener('shown.bs.tab'
 document.addEventListener('DOMContentLoaded', function() {
     const changelogMarkdownElement = document.querySelector('#changelogMarkdown');
     if (changelogMarkdownElement) {
-        const viewer = new toastui.Editor.Viewer({
+        const viewer = toastui.Editor.factory({
             el: document.querySelector('#changelogViewer'),
             initialValue: changelogMarkdownElement.value
         });


### PR DESCRIPTION
## Summary
- initialize the ToastUI changelog viewer on the milestone detail page using the factory helper so the widget loads without errors
- broaden Sigma.js detection in the semantic network viewer to recognize additional global namespaces exposed by the CDN bundle

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68fcdf815f6c8327a78217a0895892aa